### PR TITLE
feat: Add no project selected page + switching to new project page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,36 @@
+import { useState } from "react";
 import NewProject from "./components/NewProject";
+import NoProjectSelected from "./components/NoProjectSelected";
 import Sidebar from "./components/Sidebar";
 
 function App() {
+  const [isProjectsState, setIsProjectsState] = useState({
+    // Neither adding a new project nor have a project selected
+    selectedProjectId: undefined,
+    projects: [],
+  });
+
+  function handleStartAddProject() {
+    setIsProjectsState((prevState) => {
+      return {
+        ...prevState,
+        selectedProjectId: null,
+      };
+    });
+  }
+
+  let content;
+
+  if (isProjectsState.selectedProjectId === null) {
+    content = <NewProject />;
+  } else if (isProjectsState.selectedProjectId === undefined) {
+    content = <NoProjectSelected onStartAddProject={handleStartAddProject} />;
+  }
+
   return (
     <main className="h-screen my-8 flex gap-8">
-      <Sidebar />
-      <NewProject />
+      <Sidebar onStartAddProject={handleStartAddProject} />
+      {content}
     </main>
   );
 }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,12 @@
+function Button({ children, ...props }) {
+  return (
+    <button
+      className="px-4 py-2 text-xs md:text-base rounded-md bg-[#36506C] text-[#EBF7FD] hover:bg-[#A5DEF1] hover:text-[#36506C]"
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/src/components/NoProjectSelected.jsx
+++ b/src/components/NoProjectSelected.jsx
@@ -1,0 +1,25 @@
+import noProjectsImage from "../assets/no-projects.png";
+import Button from "./Button";
+
+function NoProjectSelected({ onStartAddProject }) {
+  return (
+    <div className="mt-20 text-center w-2/3">
+      <img
+        className="w-16 h-16 object-contain mx-auto"
+        src={noProjectsImage}
+        alt="An image of empty projects task list"
+      />
+      <h2 className="text-xl font-bold text-stone-600 my-4">
+        No Projects Selected
+      </h2>
+      <p className="text-stone-500 mb-4">
+        Select a project or get started with a new one
+      </p>
+      <p className="mt-8">
+        <Button onClick={onStartAddProject}>Create new project</Button>
+      </p>
+    </div>
+  );
+}
+
+export default NoProjectSelected;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,13 +1,13 @@
-function Sidebar() {
+import Button from "./Button";
+
+function Sidebar({ onStartAddProject }) {
   return (
     <aside className="w-1/3 px-8 py-16 bg-[#233142] text-stone-50 md:w-72 rounded-r-xl">
       <h2 className="mb-8 font-bold uppercase md:text-xl text-stone-100">
         You Projects
       </h2>
       <div>
-        <button className="px-4 py-2 text-xs md:text-base rounded-md bg-[#36506C] text-[#EBF7FD] hover:bg-[#EBF7FD] hover:text-[#36506C]">
-          + Add Project
-        </button>
+        <Button onClick={onStartAddProject}>+ Add Project</Button>
       </div>
       <ul></ul>
     </aside>


### PR DESCRIPTION
- Added a no projects selected component, which shows the fallback content before adding a new project.
- Page will be switched whenever one of the buttons will be clicked.

